### PR TITLE
fix potential segfault due to pointer reference and add ability to set max_norm explicitly

### DIFF
--- a/include/3d_line_detection/HoughTransform.hpp
+++ b/include/3d_line_detection/HoughTransform.hpp
@@ -36,7 +36,7 @@ template <typename POINT_CLOUD_TYPE> class HoughTransform
 
     explicit HoughTransform(const Param& param);
 
-    LineSegment3Ds run(const PointCloudPtr& cloud);
+    LineSegment3Ds run(const PointCloudPtr& cloud, float maxNorm = 0);
 
  private:
     int getLine(pcl::ModelCoefficients& coeffs, const float minRange, const float deltaRange,

--- a/include/3d_line_detection/LineSegment3D.hpp
+++ b/include/3d_line_detection/LineSegment3D.hpp
@@ -60,7 +60,7 @@ template <typename POINT_CLOUD_TYPE> class LineSegment3D
     }
 
  private:
-    const PointCloudPtr& m_cloud;
+    const PointCloudPtr m_cloud;
     pcl::ModelCoefficients m_coeffs;
     std::vector<int> m_inlierIndices;
 };

--- a/include/3d_line_detection/impl/HoughTransform.ipp
+++ b/include/3d_line_detection/impl/HoughTransform.ipp
@@ -80,13 +80,17 @@ int HoughTransform<POINT_CLOUD_TYPE>::getLine(pcl::ModelCoefficients& coeffs, co
 
 template <typename POINT_CLOUD_TYPE>
 typename HoughTransform<POINT_CLOUD_TYPE>::LineSegment3Ds
-HoughTransform<POINT_CLOUD_TYPE>::run(const PointCloudPtr& cloud)
+HoughTransform<POINT_CLOUD_TYPE>::run(const PointCloudPtr& cloud, float maxNorm)
 {
     PointCloudType minBound;
     PointCloudType maxBound;
 
     pcl::getMinMax3D(*cloud, minBound, maxBound);
-    float maxNorm = std::max<float>(this->calcNorm(minBound), this->calcNorm(maxBound));
+
+    if (maxNorm == 0) {
+        maxNorm = std::max<float>(this->calcNorm(minBound), this->calcNorm(maxBound));
+    }
+
     float range = 2 * maxNorm;
     float minRange = -maxNorm;
     float deltaRange = range / m_param.numRangeBin;


### PR DESCRIPTION
Two changes:

1.  In *LineSegment3D.hpp*, `m_cloud` is a reference to a shared pointer, so it doesn't count towards the shared pointer's reference count. This means that if the original `cloud` as passed into the contructor goes out of scope before the `LineSegment3D` does so, the shared pointer thinks it's no longer used and calls its destructor. This leads to a segfault with any further operations on the `LineSegment3D`.
2.  In *HoughTransform.ipp*, a use case I've come across a couple times now is that sometimes we know that the origin of a line falls within a certain distance from an initial point—that is, I'm only interested in searching for lines that start there. Allowing `maxNorm` to be set means it's possible to greatly reduce the time taken to find such lines, instead of finding all lines (which would take many orders of magnitude longer) and filtering them down.
    
     The new parameter defaults to 0, which maintains the original behavior by using the entire point cloud space. The reason I made it a function parameter rather than a member of `Param` is because restricting the origin search space is a per-operation configuration, rather than one that applies to the entire point cloud. (The workflow I'm using is to instantiate a single `HoughTransform` object, then use it multiple times on different initial points.)